### PR TITLE
add worst and best performance lines to data object

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -69,7 +69,9 @@ const getNetworkHistory = () => {
 
 const prepareNetworkData = data => {
   const dataObjects = Object.keys(data).map((key) => {
-    return data[key]
+    const datum = data[key]
+    datum.name = key
+    return datum
   });
   const windows = Array.from({length: 5}, (k, n) => n + 1);
 
@@ -98,6 +100,16 @@ const prepareNetworkData = data => {
   }, dataObjects[0]["mean_time_between"]);
   const overallMeanTimeBetween = sumMeanTimeBetween / dataObjects.length;
 
+  const worstLine = dataObjects.reduce((previousValue, currentValue) => {
+    const line = currentValue["mean_time_between"] > previousValue["mean_time_between"] ? currentValue : previousValue
+    return { name: line.name.slice(0,3), mean_time_between: line.mean_time_between }
+  });
+
+  const bestLine = dataObjects.reduce((previousValue, currentValue) => {
+    const line = currentValue["mean_time_between"] < previousValue["mean_time_between"] ? currentValue : previousValue
+    return { name: line.name.slice(0,3), mean_time_between: line.mean_time_between }
+  });
+
   const timestamp = dataObjects[0]["timestamp"];
   const date = dataObjects[0]["date"];
 
@@ -107,6 +119,8 @@ const prepareNetworkData = data => {
     total_scheduled_arrivals: totalScheduled,
     mean_time_between: overallMeanTimeBetween,
     timestamp: timestamp,
+    best_line: bestLine,
+    worst_line: worstLine,
     date: date
   };
   return overallData;

--- a/src/db.js
+++ b/src/db.js
@@ -100,13 +100,13 @@ const prepareNetworkData = data => {
   }, dataObjects[0]["mean_time_between"]);
   const overallMeanTimeBetween = sumMeanTimeBetween / dataObjects.length;
 
-  const worstLine = dataObjects.reduce((previousValue, currentValue) => {
-    const line = currentValue["mean_time_between"] > previousValue["mean_time_between"] ? currentValue : previousValue
+  const mostFrequent = dataObjects.reduce((previousValue, currentValue) => {
+    const line = currentValue["mean_time_between"] < previousValue["mean_time_between"] ? currentValue : previousValue
     return { name: line.name.slice(0,3), mean_time_between: line.mean_time_between }
   });
 
-  const bestLine = dataObjects.reduce((previousValue, currentValue) => {
-    const line = currentValue["mean_time_between"] < previousValue["mean_time_between"] ? currentValue : previousValue
+  const leastFrequent = dataObjects.reduce((previousValue, currentValue) => {
+    const line = currentValue["mean_time_between"] > previousValue["mean_time_between"] ? currentValue : previousValue
     return { name: line.name.slice(0,3), mean_time_between: line.mean_time_between }
   });
 
@@ -119,8 +119,8 @@ const prepareNetworkData = data => {
     total_scheduled_arrivals: totalScheduled,
     mean_time_between: overallMeanTimeBetween,
     timestamp: timestamp,
-    best_line: bestLine,
-    worst_line: worstLine,
+    most_frequent: mostFrequent,
+    least_frequent: leastFrequent,
     date: date
   };
   return overallData;

--- a/test/fixtures/sampleNetworkSummary.js
+++ b/test/fixtures/sampleNetworkSummary.js
@@ -10,11 +10,11 @@ module.exports = {
   "total_scheduled_arrivals": 24059,
   "mean_time_between": 817.471711618,
   "timestamp": "2019-03-13T14:31:14.330777-07:00",
-  "best_line": {
+  "most_frequent": {
     "mean_time_between": 590.123076923,
     "name": "803"
   },
-  "worst_line": {
+  "least_frequent": {
     "mean_time_between": 776.53652968,
     "name": "801"
   },

--- a/test/fixtures/sampleNetworkSummary.js
+++ b/test/fixtures/sampleNetworkSummary.js
@@ -9,5 +9,14 @@ module.exports = {
   "total_arrivals_analyzed": 10261,
   "total_scheduled_arrivals": 24059,
   "mean_time_between": 817.471711618,
-  "timestamp": "2019-03-13T14:31:14.330777-07:00"
+  "timestamp": "2019-03-13T14:31:14.330777-07:00",
+  "best_line": {
+    "mean_time_between": 590.123076923,
+    "name": "803"
+  },
+  "worst_line": {
+    "mean_time_between": 776.53652968,
+    "name": "801"
+  },
+  "date": "2019-03-13"
 }

--- a/test/integration/endpoints.js
+++ b/test/integration/endpoints.js
@@ -37,7 +37,7 @@ describe('GET /line', function() {
       .expect('Content-Type', /json/)
       .expect(200)
       .then(response => {
-        assert.deepEqual(Object.keys(response.body), ["ontime", "total_arrivals_analyzed", "total_scheduled_arrivals", "mean_time_between", "timestamp"])
+        assert.deepEqual(Object.keys(response.body), ["ontime", "total_arrivals_analyzed", "total_scheduled_arrivals", "mean_time_between", "timestamp", "best_line", "worst_line", "date"])
       });
   });
 

--- a/test/integration/endpoints.js
+++ b/test/integration/endpoints.js
@@ -37,7 +37,7 @@ describe('GET /line', function() {
       .expect('Content-Type', /json/)
       .expect(200)
       .then(response => {
-        assert.deepEqual(Object.keys(response.body), ["ontime", "total_arrivals_analyzed", "total_scheduled_arrivals", "mean_time_between", "timestamp", "best_line", "worst_line", "date"])
+        assert.deepEqual(Object.keys(response.body), ["ontime", "total_arrivals_analyzed", "total_scheduled_arrivals", "mean_time_between", "timestamp", "most_frequent", "least_frequent", "date"])
       });
   });
 


### PR DESCRIPTION
Adding a best and worst line object to the network data object sent to the FE. Includes line id and the mean time between for that line